### PR TITLE
初始化Sentinel Demo项目并添加必要配置

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.4.2</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <modules>
+        <module>sentinel-demo</module>
+    </modules>
+
+    <groupId>com.csdn.dev</groupId>
+    <artifactId>csdn-dev-boot</artifactId>
+    <version>${revision}</version>
+    <name>csdn-dev-boot</name>
+    <description>basic service for csdn dev</description>
+    <properties>
+        <revision>1.0.0-SNAPSHOT</revision>
+        <spring-cloud-alibaba.version>2021.1</spring-cloud-alibaba.version>
+        <boostrap.version>3.0.3</boostrap.version>
+    </properties>
+
+    <build>
+        <finalName>51job-dev-boot-mkt-media-${project.version}</finalName>
+    </build>
+
+    <dependencies>
+        <!-- spring-web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <!-- 去除spring默认的logback -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- 引入log4j2依赖 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
+
+        <!-- nacos注册中心 -->
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
+            <version>${spring-cloud-alibaba.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-starter-netflix-ribbon</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- nacos配置中心 -->
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-config</artifactId>
+            <version>${spring-cloud-alibaba.version}</version>
+        </dependency>
+
+        <!-- spring-cloud基础依赖 -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+            <version>${boostrap.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/sentinel-demo/.gitignore
+++ b/sentinel-demo/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/sentinel-demo/pom.xml
+++ b/sentinel-demo/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.csdn.dev</groupId>
+        <artifactId>csdn-dev-boot</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sentinel-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <spring-cloud-alibaba.version>2021.1</spring-cloud-alibaba.version>
+        <sentinel.transport.version>1.6.3</sentinel.transport.version>
+        <sentinel.annotation.aspectj>1.6.3</sentinel.annotation.aspectj>
+        <spring-cloud-alibaba.sentinel.version>2.1.0.RELEASE</spring-cloud-alibaba.sentinel.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-core</artifactId>
+            <version>1.6.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!--Sentinel集成控制台-->
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-transport-simple-http</artifactId>
+            <version>${sentinel.transport.version}</version>
+        </dependency>
+
+        <!--Sentinel注解依赖-->
+        <dependency>
+            <groupId>com.alibaba.csp</groupId>
+            <artifactId>sentinel-annotation-aspectj</artifactId>
+            <version>${sentinel.annotation.aspectj}</version>
+        </dependency>
+
+        <!--Sentinel集成SpringCloud-->
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-alibaba-sentinel</artifactId>
+            <version>${spring-cloud-alibaba.sentinel.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/sentinel-demo/src/main/java/com/hanson/sentinel/SentinelDemoApplication.java
+++ b/sentinel-demo/src/main/java/com/hanson/sentinel/SentinelDemoApplication.java
@@ -1,0 +1,14 @@
+package com.hanson.sentinel;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SentinelDemoApplication {
+
+    public static void main(String[] args) {
+        System.out.println("sentinel-demo成功启动(oﾟvﾟ)ノ！！！");
+        SpringApplication.run(SentinelDemoApplication.class, args);
+    }
+
+}

--- a/sentinel-demo/src/main/java/com/hanson/sentinel/controller/DashBoard.java
+++ b/sentinel-demo/src/main/java/com/hanson/sentinel/controller/DashBoard.java
@@ -1,0 +1,42 @@
+package com.hanson.sentinel.controller;
+
+import com.alibaba.csp.sentinel.annotation.SentinelResource;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author hanson.huang
+ * @version V1.0
+ * @ClassName DashBoard
+ * @Description TODO
+ * @date 2024/7/26 18:56
+ **/
+@RestController
+public class DashBoard {
+
+    /**
+     * 处理对 "/sentinel" 路径的GET请求。
+     * 此方法返回一个包含Sentinel相关信息的字符串。
+     * 当Sentinel流量控制触发时，将调用blockHandler方法。
+     *
+     * @return 包含Sentinel信息的字符串。
+     */
+    @GetMapping("dashboard")
+    @SentinelResource(value = "sentinel", blockHandler = "helloBlockHandler")
+    public String hello() {
+        return String.format("Hello sentinel............");
+    }
+
+    /**
+     * Sentinel流量控制触发的回退处理方法。
+     * 当Sentinel流量控制规则阻止了对原始方法的访问时，将调用此方法。
+     *
+     * @param e 触发流量控制的异常信息。
+     * @return 一个回退响应字符串。
+     */
+    public String helloBlockHandler(BlockException e){
+        e.printStackTrace();
+        return "this is helloBlockHandler.....";
+    }
+}

--- a/sentinel-demo/src/main/java/com/hanson/sentinel/controller/Sentinel.java
+++ b/sentinel-demo/src/main/java/com/hanson/sentinel/controller/Sentinel.java
@@ -1,0 +1,83 @@
+package com.hanson.sentinel.controller;
+
+import com.alibaba.csp.sentinel.Entry;
+import com.alibaba.csp.sentinel.SphU;
+import com.alibaba.csp.sentinel.slots.block.BlockException;
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRule;
+import com.alibaba.csp.sentinel.slots.block.flow.FlowRuleManager;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author hanson.huang
+ * @version V1.0
+ * @ClassName Sentinel
+ * @Description TODO
+ * @date 2024/7/26 18:14
+ **/
+@RestController
+public class Sentinel {
+
+    /**
+     * 处理 /sentinel 的 GET 请求。
+     * 该方法尝试进入一个 Sentinel 保护的资源。
+     * 如果由于流量控制导致资源被阻止，则捕获 BlockException 并返回 "busy" 消息。
+     * 否则，返回成功消息。
+     *
+     * @return 表示请求是否成功或被阻止的字符串。
+     */
+    @GetMapping("sentinel")
+    public String sentinel() {
+        // 声明一个Entry对象，用于后续的资源保护
+        Entry entry = null;
+
+        try {
+            // 尝试进入资源保护，如果流量超过限制，会抛出BlockException
+            SphU.entry("sentinel");
+            // 如果没有抛出异常，则返回成功消息
+            return "Hi, sentinel......!!!";
+        } catch (BlockException e) {
+            // 如果流量超过限制，捕获BlockException并打印堆栈信息，返回繁忙消息
+            e.printStackTrace();
+            return "busy......!!!";
+        } finally {
+            // 确保在最终块中退出Entry，释放资源
+            if (entry != null) {
+                entry.exit();
+                // 这个return语句会覆盖上面的return，因此不会被执行到
+                return "this is final";
+            }
+        }
+    }
+
+    /**
+     * 初始化流量控制规则。
+     * 在 Spring 容器初始化时执行，用于设置 Sentinel 的流量控制规则。
+     * 这里将资源 "sentinel" 的 QPS 限制设置为 2。
+     */
+    @PostConstruct
+    private static void initFlowRules() {
+        // 创建一个FlowRule列表，用于存储流量控制规则
+        List<FlowRule> rules = new ArrayList<>();
+
+        // 创建一个新的FlowRule对象，设置流量控制的相关参数
+        FlowRule rule = new FlowRule();
+        // 设置受保护的资源名称为"sentinel"
+        rule.setResource("sentinel");
+        // 设置流量控制的方式为QPS（每秒查询率）
+        rule.setGrade(RuleConstant.FLOW_GRADE_QPS);
+        // 设置QPS的阈值为2，即每秒最多允许2次访问
+        rule.setCount(2);
+
+        // 将这个流量控制规则添加到规则列表中
+        rules.add(rule);
+
+        // 加载这些规则到FlowRuleManager中，使其生效
+        FlowRuleManager.loadRules(rules);
+    }
+}

--- a/sentinel-demo/src/main/resources/bootstrap-dev.properties
+++ b/sentinel-demo/src/main/resources/bootstrap-dev.properties
@@ -1,0 +1,9 @@
+spring.cloud.nacos.config.server-addr=localhost:8848
+
+spring.cloud.nacos.username=nacos
+spring.cloud.nacos.password=nacos
+spring.cloud.nacos.config.username=nacos
+spring.cloud.nacos.config.password=nacos
+spring.cloud.nacos.discovery.username=nacos
+spring.cloud.nacos.discovery.password=nacos
+

--- a/sentinel-demo/src/main/resources/bootstrap.properties
+++ b/sentinel-demo/src/main/resources/bootstrap.properties
@@ -1,0 +1,9 @@
+spring.application.name=sentinel-demo-v1-config
+spring.cloud.nacos.config.server-addr=localhost:8848
+spring.cloud.nacos.config.namespace=16eb09c7-20e9-449d-8454-7628391ec946
+spring.cloud.nacos.config.group=CSDN_DEV_BOOT_GROUP
+logging.level.root=WARN
+management.endpoints.web.exposure.include=*
+
+# ?? Nacos ???????? DEBUG
+logging.level.com.alibaba.cloud.nacos=DEBUG


### PR DESCRIPTION
此次提交包括Sentinel Demo项目的初始结构搭建和相关配置文件的添加。具体改动如下：

- 创建`sentinel-demo`模块，并添加必要的`pom.xml`配置，依赖包括Spring Boot、Nacos、Sentinel等。
- 配置`bootstrap.properties`文件，以连接Nacos配置中心并设置应用名称、命名空间等信息。
- 添加`bootstrap-dev.properties`文件，包含Nacos的用户名、密码等安全配置。
- 创建`SentinelDemoApplication.java`，作为Spring Boot应用的入口点。
- 创建`DashBoard.java`和`Sentinel.java`两个控制器类，分别用于演示Sentinel的流量控制和仪表盘功能。
- 添加`.gitignore`文件，忽略IDE和构建相关的文件。
- 修改`pom.xml`文件，移除重复的依赖和调整依赖版本。

通过这些改动，我们完成了Sentinel Demo项目的基础搭建，为后续的功能开发和演示做好准备。